### PR TITLE
Generate AppImage of each Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,9 @@ script:
   - sudo mv ./usr appdir/ ; sudo chown -R $USER appdir/ # Workaround for non-functional make install
   - cd appdir ; find .
   - mkdir -p ./usr/share/applications/ # Workaround for missing desktop file in make install
-  - cp ../*.desktop ./usr/share/applications/
+  - cp ../socnetv.desktop ./usr/share/applications/
   - cp ./usr/share/pixmaps/socnetv.png .
+  - find .
   - cd .. 
   - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/3/linuxdeployqt-3-x86_64.AppImage" 
   - chmod a+x linuxdeployqt*.AppImage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+language: cpp
+compiler: gcc
+sudo: require
+dist: trusty
+
+before_install:
+    - sudo add-apt-repository ppa:beineri/opt-qt58-trusty -y
+    - sudo apt-get update -qq
+    
+install: 
+    - sudo apt-get -y install qt58base
+    - source /opt/qt58/bin/qt58-env.sh
+
+script:
+  - qmake PREFIX=/usr
+  - make -j4
+  - find .
+  - sudo apt-get -y install checkinstall
+  - sudo checkinstall --pkgname=app --pkgversion="1" --pkgrelease="1" --backup=no --fstrans=no --default --deldoc 
+  - mkdir appdir ; cd appdir
+  - dpkg -x ../app_1-1_amd64.deb . ; find .
+  - cp ./usr/share/applications/*.desktop .
+  - cp ./usr/share/icons/hicolor/48x48/apps/*.png .
+  - cd .. 
+  - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/3/linuxdeployqt-3-x86_64.AppImage" 
+  - chmod a+x linuxdeployqt*.AppImage
+  - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
+  - ./linuxdeployqt*.AppImage ./appdir/usr/bin/* -bundle-non-qt-libs
+  - ./linuxdeployqt*.AppImage ./appdir/usr/bin/* -appimage 
+  - curl --upload-file ./APPNAME*.AppImage https://transfer.sh/APPNAME-git.$(git rev-parse --short HEAD)-x86_64.AppImage

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ script:
   - sudo make install # Does not write to /usr
   - find .
   - mkdir -p appdir
-  - mv ./usr appdir/ # Workaround for non-functional make install
+  - sudo mv ./usr appdir/ ; sudo chown -R $USER appdir/ # Workaround for non-functional make install
   - cd appdir ; find .
   - cp ./usr/share/applications/*.desktop .
   - cp ./usr/share/icons/hicolor/48x48/apps/*.png .

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ script:
   - cd appdir ; find .
   - mkdir -p ./usr/share/applications/ # Workaround for missing desktop file in make install
   - cp ../*.desktop ./usr/share/applications/
-  - cp ./usr/share/icons/hicolor/48x48/apps/*.png .
+  - cp ./usr/share/pixmaps/socnetv.png .
   - cd .. 
   - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/3/linuxdeployqt-3-x86_64.AppImage" 
   - chmod a+x linuxdeployqt*.AppImage

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,11 @@ install:
 script:
   - qmake PREFIX=/usr
   - make -j4
+  - sudo make install # Does not write to /usr
   - find .
-  - sudo apt-get -y install checkinstall
-  - sudo checkinstall --pkgname=app --pkgversion="1" --pkgrelease="1" --backup=no --fstrans=no --default --deldoc 
-  - mkdir appdir ; cd appdir
-  - dpkg -x ../app_1-1_amd64.deb . ; find .
+  - mkdir -p appdir
+  - mv app/usr appdir/ # Workaround for non-functional make install
+  - cd appdir ; find .
   - cp ./usr/share/applications/*.desktop .
   - cp ./usr/share/icons/hicolor/48x48/apps/*.png .
   - cd .. 
@@ -27,4 +27,4 @@ script:
   - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
   - ./linuxdeployqt*.AppImage ./appdir/usr/bin/* -bundle-non-qt-libs
   - ./linuxdeployqt*.AppImage ./appdir/usr/bin/* -appimage 
-  - curl --upload-file ./APPNAME*.AppImage https://transfer.sh/APPNAME-git.$(git rev-parse --short HEAD)-x86_64.AppImage
+  - curl --upload-file ./SocNetV*.AppImage https://transfer.sh/SocNetV-git.$(git rev-parse --short HEAD)-x86_64.AppImage

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,8 @@ script:
   - mkdir -p appdir
   - sudo mv ./usr appdir/ ; sudo chown -R $USER appdir/ # Workaround for non-functional make install
   - cd appdir ; find .
-  - cp ./usr/share/applications/*.desktop .
+  - mkdir -p ./usr/share/applications/ # Workaround for missing desktop file in make install
+  - cp ../*.desktop ./usr/share/applications/
   - cp ./usr/share/icons/hicolor/48x48/apps/*.png .
   - cd .. 
   - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/3/linuxdeployqt-3-x86_64.AppImage" 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,8 @@ script:
   - sudo mv ./usr appdir/ ; sudo chown -R $USER . # Workaround for non-functional make install
   - cd appdir ; find .
   - mkdir -p ./usr/share/applications/ # Workaround for missing desktop file in make install
-  - cp ../socnetv.desktop ./usr/share/applications/ .
+  - cp ../socnetv.desktop ./usr/share/applications/
+  - cp ../socnetv.desktop .
   - cp ./usr/share/pixmaps/socnetv.png .
   - find .
   - cd .. 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ script:
   - sudo make install # Does not write to /usr
   - find .
   - mkdir -p appdir
-  - mv app/usr appdir/ # Workaround for non-functional make install
+  - mv ./usr appdir/ # Workaround for non-functional make install
   - cd appdir ; find .
   - cp ./usr/share/applications/*.desktop .
   - cp ./usr/share/icons/hicolor/48x48/apps/*.png .

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,10 @@ script:
   - sudo make install # Does not write to /usr
   - find .
   - mkdir -p appdir
-  - sudo mv ./usr appdir/ ; sudo chown -R $USER appdir/ # Workaround for non-functional make install
+  - sudo mv ./usr appdir/ ; sudo chown -R $USER . # Workaround for non-functional make install
   - cd appdir ; find .
   - mkdir -p ./usr/share/applications/ # Workaround for missing desktop file in make install
-  - cp ../socnetv.desktop ./usr/share/applications/
+  - cp ../socnetv.desktop ./usr/share/applications/ .
   - cp ./usr/share/pixmaps/socnetv.png .
   - find .
   - cd .. 


### PR DESCRIPTION
This PR, when merged, will compile this application on [Travis CI](https://travis-ci.org/) upon each `git push`, and upload an [AppImage](http://appimage.org/) to a temporary download URL on transfer.sh (available for 14 days). The download URL is toward the end of each Travis CI build log of each build (see below for how to set up automatic uploading to your GitHub Releases page).

For this to work, you need to enable Travis CI for your repository as [described here](https://travis-ci.org/getting_started) __prior to merging this__, if you haven't already done so.

Providing an [AppImage](http://appimage.org/) would have, among others, these advantages:
- Works for most Linux distributions (including Ubuntu, Fedora, openSUSE, CentOS, elementaryOS, Linux Mint, and others)
- One app = one file = super simple for users: just download one AppImage file, [make it executable](http://discourse.appimage.org/t/how-to-make-an-appimage-executable/80), and run
- No unpacking or installation necessary
- No root needed
- No system libraries changed
- Just one format for all major distributions
- Works out of the box, no installation of runtimes needed
- Optional desktop integration with `appimaged`
- Optional binary delta updates, e.g., for continuous builds (only download the binary diff) using AppImageUpdate
- Can optionally GPG2-sign your AppImages (inside the file)

[Here is an overview](https://github.com/probonopd/AppImageKit/wiki/AppImages) of projects that are already distributing upstream-provided, official AppImages.

__Please note:__ Instead of storing AppImage builds temporarily for 14 days each on transfer.sh, you could use GitHub Releases to store the binaries permanently. This way, they would be visible on the Releases page of your project. This is what I recommend. See https://docs.travis-ci.com/user/deployment/releases/. If you want to do this for continuous builds, also see https://github.com/probonopd/uploadtool.

If you would like to see only one entry for the Pull Request in your project's history, then please enable [this GitHub functionality](https://help.github.com/articles/configuring-commit-squashing-for-pull-requests/) on your repo. It allows you to squash (combine) the commits when merging.

If you have questions, AppImage developers are on #AppImage on irc.freenode.net.