### PR TITLE
Fixed typos

### DIFF
--- a/src/graph.cpp
+++ b/src/graph.cpp
@@ -23102,7 +23102,7 @@ QString Graph::graphClusteringMethodTypeToString(const int &methodType) const {
     QString methodStr;
     switch (methodType) {
     case Clustering::Single_Linkage:
-        methodStr = "Single-linkage (minumum)";
+        methodStr = "Single-linkage (minimum)";
         break;
     case Clustering::Complete_Linkage:
         methodStr = "Complete-linkage (maximum)";

--- a/src/graphvertex.cpp
+++ b/src/graphvertex.cpp
@@ -141,7 +141,7 @@ GraphVertex::GraphVertex(const int &name) {
 void GraphVertex::relationSet(int newRel) {
     qDebug() << "GraphVertex::relationSet() - vertex:" << name()
              << "current relation:" << m_curRelation
-             << "settting new relation: " << newRel;
+             << "setting new relation: " << newRel;
     // first make false all edges of current relation
     edgeFilterByRelation(m_curRelation, false);
     // then make true all edges of new relation

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -13347,8 +13347,8 @@ void MainWindow::slotOptionsEdgesBezier(bool toggle){
  * @brief MainWindow::slotOptionsEdgeThicknessPerWeight
  * @param toggle
  */
-void MainWindow::slotOptionsEdgeThicknessPerWeight(bool toogle) {
-    if (toogle) {
+void MainWindow::slotOptionsEdgeThicknessPerWeight(bool toggle) {
+    if (toggle) {
 
     }
     else {


### PR DESCRIPTION
While I was trying to build the release 2.7 for Debian,  Lintian reported
"spelling-error-in-binary".

This is the patch it should fix it.
This was already reported (please see #111) but due to a wrong target
branch it had to be manually added and some changes weren't in place.