### PR TITLE
Typo

### DIFF
--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -490,7 +490,7 @@ public slots:
     void slotOptionsEdgeLabelsVisibility(bool toggle);
     void slotOptionsEdgeWeightNumbersVisibility(bool toggle);
     void slotOptionsEdgeWeightsDuringComputation(bool);
-    void slotOptionsEdgeThicknessPerWeight(bool toogle);
+    void slotOptionsEdgeThicknessPerWeight(bool toggle);
     void slotOptionsEdgesBezier(bool toggle);
     void slotOptionsEdgeArrowsVisibility(bool toggle);
 
@@ -501,7 +501,7 @@ public slots:
     void slotOptionsWindowStatusbarVisibility(bool toggle);
     void slotOptionsWindowLeftPanelVisibility(bool toggle);
     void slotOptionsWindowRightPanelVisibility(bool toggle);
-    void slotOptionsWindowFullScreen(bool toogle);
+    void slotOptionsWindowFullScreen(bool toggle);
 
     void slotOptionsDebugMessages(bool toggle);
 


### PR DESCRIPTION
Following up #115 there is yet another typo found by Lintian that I forgot
to push. This should be the last one as per the results I got from the
command `lintian -Ivi`.