### PR TITLE
fix incorrect URL path on wiktionary.org

### DIFF
--- a/src/forms/dialogwebcrawler.cpp
+++ b/src/forms/dialogwebcrawler.cpp
@@ -132,7 +132,7 @@ void DialogWebCrawler::checkErrors(){
 
     qDebug()<< "seed url:" << seedUrlInputStr << "Sanitizing...";
 
-    seedUrlInputStr = seedUrlInputStr.simplified().toLower() ;
+    seedUrlInputStr = seedUrlInputStr.simplified();
 
     seedUrl = QUrl(seedUrlInputStr);
 


### PR DESCRIPTION
[Wiktionary.org](//en.wiktionary.org) (and probably other sites too) uses _**case-sensitive**_ url path. So it is incorrect to make it lowercase unconditionally